### PR TITLE
Dask disk store proof of concept

### DIFF
--- a/modin/dask_store.py
+++ b/modin/dask_store.py
@@ -1,0 +1,37 @@
+import os
+import uuid
+
+import dask.distributed
+import pandas
+
+
+class DiskStore(object):
+    """A simple disk storage for Pandas objects
+
+    TODO: Does not clean the disk!!!
+
+    Args:
+        basepath (str): Directory for storing data files
+    """
+
+    def __init__(self, basepath="/tmp/modin_store"):
+        self.basepath = basepath
+        if not os.path.exists(basepath):
+            os.makedirs(basepath)
+        assert os.path.isdir(basepath)
+
+    def put(self, obj):
+        filename = str(uuid.uuid4()) + ".pickle"
+        obj.to_pickle(os.path.join(self.basepath, filename))
+        return filename
+
+    def get(self, filename):
+        return pandas.read_pickle(os.path.join(self.basepath, filename))
+
+    def __getitem__(self, filename):
+        return self.get(filename)
+
+    def put_wrap(self, obj):
+        """Stores obj and returns dask.delayed object which evaluates to obj"""
+        filename = self.put(obj)
+        return dask.delayed(pandas.read_pickle)(os.path.join(self.basepath, filename))

--- a/modin/data_management/partitioning/remote_partition/dask.py
+++ b/modin/data_management/partitioning/remote_partition/dask.py
@@ -1,11 +1,16 @@
-import pandas
 import dask.dataframe
+import pandas
+
+from modin import dask_store
 
 from .base_remote_partition import BaseRemotePartition
 from .utils import length_fn_pandas, width_fn_pandas
 
 
 class DaskRemotePartition(BaseRemotePartition):
+
+    _disk_store = dask_store.DiskStore()
+
     def __init__(self, dask_obj):
         self.dask_obj = dask_obj
 
@@ -68,7 +73,7 @@ class DaskRemotePartition(BaseRemotePartition):
             A `RemotePartitions` object.
         """
         # simply wrap the input object by dask.delayed
-        return cls(dask.delayed(obj))
+        return cls(cls._disk_store.put_wrap(obj))
 
     @classmethod
     def preprocess_func(cls, func):


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Enables storing (large) data on disk, uses pandas pickles wrapped in `dask.delayed`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
